### PR TITLE
incluo método para deletar contato recebendo cpf

### DIFF
--- a/aula-05/projeto-agenda/functions.rb
+++ b/aula-05/projeto-agenda/functions.rb
@@ -49,8 +49,17 @@ end
 
 # Método para deletar um contato na agenda (deve receber CPF)
 def delete(cpf)
-
+  if  @contacts.any? { |item| item[:cpf] == cpf}
+    @contacts.map { |item| 
+      @contacts.delete(item)
+      puts "Cpf #{cpf} excluído com sucesso."
+      break
+    }
+  else 
+    puts "Não foi possível excluir o Cpf #{cpf}"
+  end
 end
+
 
 # Método para consultar um contato na agenda (deve receber NOME ou EMAIL/TELEFONE ou CPF) e imprimir na tela os dados do contato
 def view(text_search)


### PR DESCRIPTION
## Descrição

Este PR inclui o método para deletar um contato, recebendo como parâmetro o número de cpf. 
Este PR assume que a estrutura da agenda para armazenar contatos segue o seguinte exemplo (um array de hashes):

`
@contacts = [
   {:nome => "Ana", :telefone => 1199999999, :cpf => 12345678901},
   {:nome => "Paula", :telefone => 11888888, :cpf => 12345678902},
   {:nome => "Ana Paula", :telefone => 11777777, :cpf => 12345678903}
  ]
`

## Critérios de aceite

- [x] Usuário deve conseguir excluir o contato.
- [x] Usuário deve poder visualizar mensagem de sucesso.
- [x] Caso cpf não seja existente no array, usuário deve visualizar mensagem de erro.


## Tipo de alteração

|     | Tipo                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: Novo feature     |
|    | :hammer: Refatoração       |
|    | :100: Adiciona testes         |
|    | :link: Atualiza dependências |
|    | :scroll: Documentação              |
